### PR TITLE
Disable manual input for due date fields

### DIFF
--- a/src/app/kanban-add-overlay/kanban-add-overlay.component.html
+++ b/src/app/kanban-add-overlay/kanban-add-overlay.component.html
@@ -28,7 +28,7 @@
 						<label class="form-label">
 							Due date<span class="required-asterisk">*</span>
 						</label>
-						<input [(ngModel)]="taskList.dueDate" class="input-date" type="date" [min]="currentDate" name="dueDate" required
+						<input [(ngModel)]="taskList.dueDate" class="input-date" type="date" onkeydown="return false;" [min]="currentDate" name="dueDate" required
 							#dueDate="ngModel" [class.errorborder]="!dueDate.valid && dueDate.touched" />
 					</div>
 					<div class="invalid-input">

--- a/src/app/kanban/kanban-edit/kanban-edit.component.html
+++ b/src/app/kanban/kanban-edit/kanban-edit.component.html
@@ -16,7 +16,7 @@
                     </div>
                     <div class="form-date kanban-div">
                         <span>Due date</span>
-                        <input type="date" [(ngModel)]="task.dueDate" name="taskDate" [min]="currentDate"/>
+                        <input type="date" [(ngModel)]="task.dueDate" name="taskDate" [min]="currentDate" onkeydown="return false;"/>
                     </div>
                 </form>
 


### PR DESCRIPTION
Added 'onkeydown="return false;"' to date input fields in kanban-add-overlay and kanban-edit components to prevent manual typing and enforce date selection via the picker.