### PR TITLE
Enforce +49 prefix and numeric input for phone fields

### DIFF
--- a/src/app/contacts/overlay-contacts/overlay-contacts.component.html
+++ b/src/app/contacts/overlay-contacts/overlay-contacts.component.html
@@ -68,14 +68,14 @@
               </div>
 
               <div class="inputAreas">
-                <input [(ngModel)]="contactList.phone" class="phone" type="number" placeholder="Phone" name="phone"
-                  required pattern="^\+?[0-9\s]{6,16}$" id="phone" #phone="ngModel"
-                  [class.invalid]=" phone.invalid && phone.dirty " />
-                <div class="invalid-input">
-                  @if (phone.invalid && phone.dirty) {
-                    <div>Example: +49 30 1234567</div>
-                  }
-                </div>
+                <input [(ngModel)]="contactList.phone" class="phone" type="text" placeholder="Phone"
+                name="phone" required pattern="^[0-9]{6,16}$" id="phone" #phone="ngModel"
+                [class.invalid]=" phone.invalid && phone.dirty " (input)="addPrefix()" maxlength="15" (keypress)="allowOnlyNumbersAndPlus($event)"/>
+              <div class="invalid-input">
+                @if (phone.invalid && phone.dirty || !contactForm.valid) {
+                <div>Example: +49301234567</div>
+                }
+              </div>
               </div>
 
               } @case ('editContact') {
@@ -98,9 +98,9 @@
                 }
               </div>
 
-              <input [(ngModel)]="overlayState.selectedUser.phone" class="phone" type="tel" placeholder="Phone"
-                name="phone" required pattern="^\+?[0-9\s]{6,16}$" id="phone" #phone="ngModel"
-                [class.invalid]=" phone.invalid && phone.dirty " maxlength="15"/>
+              <input [(ngModel)]="overlayState.selectedUser.phone" class="phone" type="text" placeholder="Phone"
+                name="phone" required pattern="^[0-9]{6,16}$" id="phone" #phone="ngModel"
+                [class.invalid]=" phone.invalid && phone.dirty " (input)="addPrefix()" maxlength="15" (keypress)="allowOnlyNumbersAndPlus($event)"/>
               <div class="invalid-input">
                 @if (phone.invalid && phone.dirty || !contactForm.valid) {
                 <div>Example: +49301234567</div>

--- a/src/app/contacts/overlay-contacts/overlay-contacts.component.ts
+++ b/src/app/contacts/overlay-contacts/overlay-contacts.component.ts
@@ -10,6 +10,15 @@ import { ContactList } from "../../shared/interface/contact-list.interface";
     styleUrl: './overlay-contacts.component.scss',
 })
 export class OverlayContactsComponent {
+    /**
+     * Verhindert die Eingabe von Buchstaben im Telefonnummernfeld
+     */
+    allowOnlyNumbersAndPlus(event: KeyboardEvent) {
+        const allowed = /[0-9+]/;
+        if (!allowed.test(event.key)) {
+            event.preventDefault();
+        }
+    }
     splittedName?: string[];
 
     editFullName?: string;
@@ -82,5 +91,24 @@ export class OverlayContactsComponent {
             this.contactList.firstName.charAt(0).toUpperCase() +
             this.contactList.lastName.charAt(0).toUpperCase();
         this.contactList.color = this.overlayState.getRandomColor();
+    }
+
+    /**
+     * Ensures that the phone number always starts with +49 and cannot be removed
+     * Works for both addContact (contactList.phone) and editContact (selectedUser.phone)
+     */
+    addPrefix() {
+        // addContact case
+        if (this.contactList && this.contactList.phone !== undefined) {
+            if (!this.contactList.phone.startsWith('+49')) {
+                this.contactList.phone = '+49' + this.contactList.phone.replace(/^\+?49/, '');
+            }
+        }
+        // editContact case
+        if (this.overlayState.selectedUser && this.overlayState.selectedUser.phone !== undefined) {
+            if (!this.overlayState.selectedUser.phone.startsWith('+49')) {
+                this.overlayState.selectedUser.phone = '+49' + this.overlayState.selectedUser.phone.replace(/^\+?49/, '');
+            }
+        }
     }
 }


### PR DESCRIPTION
Added input validation to restrict phone number fields to numbers and plus sign only, and ensure all phone numbers start with the +49 prefix for both add and edit contact forms. Updated HTML input attributes and error messages to reflect these changes.